### PR TITLE
Add sizeof() around fz_quad in fz_malloc_array

### DIFF
--- a/zathura-pdf-mupdf/search.c
+++ b/zathura-pdf-mupdf/search.c
@@ -39,7 +39,7 @@ pdf_page_search_text(zathura_page_t* page, void* data, const char* text, zathura
     mupdf_page_extract_text(mupdf_document, mupdf_page);
   }
 
-  fz_quad* hit_bbox = fz_malloc_array(mupdf_page->ctx, N_SEARCH_RESULTS, fz_quad);
+  fz_quad* hit_bbox = fz_malloc_array(mupdf_page->ctx, N_SEARCH_RESULTS, sizeof(fz_quad));
   int num_results = fz_search_stext_page(mupdf_page->ctx, mupdf_page->text,
       text, hit_bbox, N_SEARCH_RESULTS);
 


### PR DESCRIPTION
this fixes compilation on picky compilers, ie: clang-10 with `std=c2x'

```
../zathura-pdf-mupdf-0.3.5/zathura-pdf-mupdf/search.c:42:74: error: unexpected type name 'fz_quad': expected expression
  fz_quad* hit_bbox = fz_malloc_array(mupdf_page->ctx, N_SEARCH_RESULTS, fz_quad);
                                                                         ^
1 error generated.
```

As a sidenote, gitlab blocks signups when using an email address on "yandex.com", including the login-with-github option, too. I would have preferred to submit this MR on gitlab, sorry for any trouble.