### PR TITLE
FictionBook (fb2) support

### DIFF
--- a/zathura-pdf-mupdf/plugin.c
+++ b/zathura-pdf-mupdf/plugin.c
@@ -24,6 +24,8 @@ ZATHURA_PLUGIN_REGISTER_WITH_FUNCTIONS(
   ZATHURA_PLUGIN_MIMETYPES({
     "application/pdf",
     "application/oxps",
-    "application/epub+zip"
+    "application/epub+zip",
+    "application/x-fictionbook",
+    "text/xml"
   })
 )


### PR DESCRIPTION
Since mupdf already has [fb2](https://en.wikipedia.org/wiki/FictionBook) support, I don't see any reason not to support this format in zathura-pdf-mupdf.

Random books from my collection were displayed correctly, and I didn't notice the patch's effect on the program's stability.