### PR TITLE
Adapt search.c to MuPDF API change

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The following dependencies are required:
 
 * `zathura` (>= 0.2.0)
 * `girara`
-* `mupdf` (>= 1.19)
+* `mupdf` (>= 1.20.0)
 
 For building plugin, the following dependencies are also required:
 

--- a/zathura-pdf-mupdf/search.c
+++ b/zathura-pdf-mupdf/search.c
@@ -41,7 +41,7 @@ pdf_page_search_text(zathura_page_t* page, void* data, const char* text, zathura
 
   fz_quad* hit_bbox = fz_malloc_array(mupdf_page->ctx, N_SEARCH_RESULTS, fz_quad);
   int num_results = fz_search_stext_page(mupdf_page->ctx, mupdf_page->text,
-      text, hit_bbox, N_SEARCH_RESULTS);
+      text, NULL, hit_bbox, N_SEARCH_RESULTS);
 
   fz_rect r;
   for (int i = 0; i < num_results; i++) {


### PR DESCRIPTION
In MuPdf-1.20.0 the search API, in particular the function
fz_search_stext_page was extended by an additional parameter.

Because of that, building zathura-pdf-mupdf against MuPDF-1.20.0 fails.

Therefore, I adapted the fz_search_stext_page call, adding NULL as the
new hit_mark parameter.

From this change on, >=MuPDF-1.20.0 is necessary to build
zathura-pdf-mupdf.