### PR TITLE
support loading cbz files

### DIFF
--- a/zathura-pdf-mupdf/plugin.c
+++ b/zathura-pdf-mupdf/plugin.c
@@ -26,6 +26,7 @@ ZATHURA_PLUGIN_REGISTER_WITH_FUNCTIONS(
     "application/pdf",
     "application/oxps",
     "application/epub+zip",
+    "application/zip", /* mupdf supports cbz */
     "application/x-fictionbook",
     "text/xml"
   })


### PR DESCRIPTION
mupdf supports cbz files, so whitelist "application/zip".