### PR TITLE
fix: add missing zathura icon in desktop file

### DIFF
--- a/data/org.pwmt.zathura-pdf-mupdf.desktop
+++ b/data/org.pwmt.zathura-pdf-mupdf.desktop
@@ -4,6 +4,7 @@ Type=Application
 Name=Zathura
 Comment=A minimalistic document viewer
 Exec=zathura %U
+Icon=org.pwmt.zathura
 Terminal=false
 NoDisplay=true
 Categories=Office;Viewer;


### PR DESCRIPTION
The lack of icon can result in having no zathura icon shown when trying to open a file using suggested applications.
Although this desktop file is not meant to be shown in app launchers it's used to decide with what software a file should be opened, and some of those menus do display icons.