### PR TITLE
fix: pdf metadata is not shown

### DIFF
--- a/zathura-pdf-mupdf/document.c
+++ b/zathura-pdf-mupdf/document.c
@@ -127,7 +127,7 @@ zathura_error_t pdf_document_save_as(zathura_document_t* document, void* data, c
 girara_list_t* pdf_document_get_information(zathura_document_t* document, void* data, zathura_error_t* error) {
   mupdf_document_t* mupdf_document = data;
 
-  if (document == NULL || mupdf_document == NULL || error == NULL) {
+  if (document == NULL || mupdf_document == NULL) {
     if (error != NULL) {
       *error = ZATHURA_ERROR_INVALID_ARGUMENTS;
     }
@@ -171,7 +171,7 @@ girara_list_t* pdf_document_get_information(zathura_document_t* document, void* 
         continue;
       }
 
-      char* str_value = pdf_to_str_buf(mupdf_document->ctx, value);
+      const char* str_value = pdf_to_text_string(mupdf_document->ctx, value);
       if (str_value == NULL || strlen(str_value) == 0) {
         continue;
       }
@@ -195,7 +195,7 @@ girara_list_t* pdf_document_get_information(zathura_document_t* document, void* 
         continue;
       }
 
-      char* str_value = pdf_to_str_buf(mupdf_document->ctx, value);
+      const char* str_value = pdf_to_text_string(mupdf_document->ctx, value);
       if (str_value == NULL || strlen(str_value) == 0) {
         continue;
       }


### PR DESCRIPTION
The command `:info` does not display the metadata of the PDF document.
Instead, a white line is shown at the bottom of the screen and an error
message is logged to the console. This is because of a misinterpretation
of the string buffer, returned from `pdf_to_str_buf`. The content of the
string buffer is `UTF-16be` encoded and therefore not suitable for
passing to the zathura API, which expects an `UTF-8` encoded sequence.
By using the function `pdf_to_text_string` the `UTF-8` conversion is
done by `mupdf` and no further steps are required.

This resolves #43, resolves #24
