### PR TITLE
Add images support

### DIFF
--- a/data/org.pwmt.zathura-pdf-mupdf.desktop
+++ b/data/org.pwmt.zathura-pdf-mupdf.desktop
@@ -8,4 +8,4 @@ Icon=org.pwmt.zathura
 Terminal=false
 NoDisplay=true
 Categories=Office;Viewer;
-MimeType=@PDF@application/oxps;application/epub+zip;application/x-fictionbook;application/x-mobipocket-ebook;
+MimeType=@PDF@application/oxps;application/epub+zip;application/x-fictionbook;application/x-mobipocket-ebook;image/svg+xml;image/jpeg;image/png;image/bmp;image/x-bmp;image/tiff;image/tiff-fx;

--- a/zathura-pdf-mupdf/plugin.c
+++ b/zathura-pdf-mupdf/plugin.c
@@ -33,4 +33,11 @@ ZATHURA_PLUGIN_REGISTER_WITH_FUNCTIONS("pdf-mupdf", VERSION_MAJOR, VERSION_MINOR
                                            "application/x-fictionbook",
                                            "application/x-mobipocket-ebook",
                                            "text/xml",
+                                           "image/svg+xml",
+                                           "image/jpeg",
+                                           "image/png",
+                                           "image/bmp",
+                                           "image/x-bmp",
+                                           "image/tiff",
+                                           "image/tiff-fx",
                                        }))


### PR DESCRIPTION
Based on MuPDF documentation, MuPDF supports the following file formats: pdf, epub, xps, cbz, mobi, fb2, svg and a suite of image types, e.g. png, jpg, bmp etc.

Based on source code (file `source/fitz/image-imp.h` and other files in the same directory), MuPDF supports following image formats: jpeg, png, psd, tiff, jxr, gif, bmp, pnm, jbig2.

Here is table of MIME types for all of that types and list of extensions (here `x{a,b,c}y` means `xay`, `xby`, `xcy`):
| type  | MIME type                        | extensions                           |
|-------|----------------------------------|--------------------------------------|
| pdf   | `application/{,x-,x-bz,x-gz}pdf`,| .pdf                                 |
| epub  | `application/epub+zip`           | .epub                                |
| xps   | `application/oxps`,              | .oxps, .xps                          |
|       | `application/vnd.ms-xpsdocument` |                                      |
| cbz   | `application/vnd.comicbook+zip`, | .cbz                                 |
|       | `application/vnd.comicbook-rar`  | .cbr                                 |
|       |                                  | .cbt, .cba, .cb7                     |
| mobi  | `application/x-mobipocket-ebook` | .mobi                                |
| fb2   | `application/fictionbook2+zip`,  | .fb2, .fbz, .fb2.zip                 |
|       | `application/x-fictionbook`      |                                      |
| svg   | `image/svg+xml`                  | .svg, .svgz                          |
| jpeg  | `image/jpeg`                     | .jpg, .jpeg, .jpe, .jif, .jfif, .jfi |
| png   | `image/png`                      | .png                                 |
| psd   | `image/vnd.adobe.photoshop`      | .psd                                 |
| tiff  | `image/tiff{,-fx}`               | .tiff, .tif                          |
| jxr   | `image/{vnd.ms-photo,image/jxr}` | .jxr, .hdp, .wdp                     |
| gif   | `image/gif`                      | .gif                                 |
| bmp   | `image/{,x-}bmp`                 | .bmp, .dib                           |
| pnm   | `image/x-portable-{bit,gray,pix,any}map` | .pbm, .pgm, .ppm, .pnm       |
| jbig2 | `image/x-jbig2`                  | ???                                  |

This PR update list of supported MIME types. It adds MIME types for popular image formats: svg, jpeg, png, bmp, tiff. All MIME types, which have been added, have been tested.

links:
- https://mupdf.readthedocs.io/en/latest/quick-start-guide.html#supported-file-formats
