### PR TITLE
Fix image export

### DIFF
--- a/zathura-pdf-mupdf/image.c
+++ b/zathura-pdf-mupdf/image.c
@@ -125,7 +125,7 @@ cairo_surface_t* pdf_page_image_get_cairo(zathura_page_t* page, void* data, zath
       guchar* p = surface_data + y * rowstride + x * 4;
 
       // RGB
-      if (n == 4) {
+      if (n == 3) {
         p[0] = s[2];
         p[1] = s[1];
         p[2] = s[0];

--- a/zathura-pdf-mupdf/image.c
+++ b/zathura-pdf-mupdf/image.c
@@ -40,7 +40,9 @@ girara_list_t* pdf_page_images_get(zathura_page_t* page, void* data, zathura_err
 
   /* Extract images */
   g_mutex_lock(&mupdf_document->mutex);
-  mupdf_page_extract_text(mupdf_document, mupdf_page);
+  if (!mupdf_page->extracted_text) {
+    mupdf_page_extract_text(mupdf_document, mupdf_page);
+  }
 
   fz_stext_block* block;
   for (block = mupdf_page->text->first_block; block; block = block->next) {

--- a/zathura-pdf-mupdf/utils.c
+++ b/zathura-pdf-mupdf/utils.c
@@ -10,10 +10,9 @@ void mupdf_page_extract_text(mupdf_document_t* mupdf_document, mupdf_page_t* mup
   fz_device* volatile text_device = NULL;
 
   fz_try(mupdf_page->ctx) {
-    text_device = fz_new_stext_device(mupdf_page->ctx, mupdf_page->text, NULL);
-
-    /* Disable FZ_DONT_INTERPOLATE_IMAGES to collect image blocks */
-    fz_disable_device_hints(mupdf_page->ctx, text_device, FZ_DONT_INTERPOLATE_IMAGES);
+    fz_stext_options stext_options;
+    stext_options.flags = FZ_STEXT_PRESERVE_IMAGES;
+    text_device = fz_new_stext_device(mupdf_page->ctx, mupdf_page->text, &stext_options);
 
     fz_matrix ctm;
     ctm = fz_scale(1.0, 1.0);

--- a/zathura-pdf-mupdf/utils.c
+++ b/zathura-pdf-mupdf/utils.c
@@ -14,9 +14,7 @@ void mupdf_page_extract_text(mupdf_document_t* mupdf_document, mupdf_page_t* mup
     stext_options.flags = FZ_STEXT_PRESERVE_IMAGES;
     text_device = fz_new_stext_device(mupdf_page->ctx, mupdf_page->text, &stext_options);
 
-    fz_matrix ctm;
-    ctm = fz_scale(1.0, 1.0);
-    fz_run_page(mupdf_page->ctx, mupdf_page->page, text_device, ctm, NULL);
+    fz_run_page(mupdf_page->ctx, mupdf_page->page, text_device, fz_identity, NULL);
   }
   fz_always(mupdf_document->ctx) {
     fz_close_device(mupdf_page->ctx, text_device);


### PR DESCRIPTION
Started work on fixing image export (see #88). The plugin now recognizes the list of images and populates the export list in `zathura`. A problem left is that exported images are black and white.

I don't know why disabling device hints like this...
```C
fz_disable_device_hints(mupdf_page->ctx, text_device, FZ_DONT_INTERPOLATE_IMAGES);
```
makes `text_device` ignore images.

Also, the list entries would get duplicated every time you enter `export:<Tab>` in `zathura`. This should now be fixed by checking the `extracted_text` flag.