### PR TITLE
Read custom CSS for epub if present from ~/.config/

### DIFF
--- a/zathura-pdf-mupdf/document.c
+++ b/zathura-pdf-mupdf/document.c
@@ -41,7 +41,7 @@ zathura_error_t pdf_document_open(zathura_document_t* document) {
     /* read user css from zathura/epub.css */
     char* xdg_path = girara_get_xdg_path(XDG_CONFIG);
     if (xdg_path) {
-        char* css_path = g_strconcat(xdg_path, "/epub.css", NULL);
+        char* css_path = g_strconcat(xdg_path, "/zathura/epub.css", NULL);
         char* user_css = girara_file_read(css_path);
         g_free(css_path);
 


### PR DESCRIPTION
Closes #22 

This PR adds support for a custom CSS file.

Huge caveat: I am not a C developer outside of a couple university classes a fair few years ago, so all I've done here is check the mupdf API for the appropriate calls and set up reading the stylesheet. Reading the XDG config file is done here using a function I had an LLM write (hence the comments and likely poor style). I fully expect someone who actually knows what they're doing can do better.

This appears to work when tested (I changed font-family and got different epub rendering), but can likely be improved on all grounds.

Other questions

1. Code organisation - do you want this in the utils file and to add the additional include? 
2. Plugin doing I/O - is there a better way in Zathura to allow plugins to add config to zathurarc? Or should I just do the I/O and reading again here? I suspect the plugin API may mean we don't need separate file reading functionality.
3. Error handling - currently this will crash if we fail to set the CSS correctly on opening a file, where perhaps the plugin wants to separate (or at least notify user) of this?

Anyway - hopefully this is a decent start point and someone who has a better understanding of the project can figure the details out :)