### PR TITLE
add missing lock and fix buffer size

### DIFF
--- a/zathura-pdf-mupdf/attachment.c
+++ b/zathura-pdf-mupdf/attachment.c
@@ -40,6 +40,7 @@ girara_list_t* pdf_document_attachments_get(zathura_document_t* document, void* 
     if (error != NULL) {
       *error = ZATHURA_ERROR_UNKNOWN;
     }
+    g_mutex_unlock(&mupdf_document->mutex);
     goto error_free;
   }
   g_mutex_unlock(&mupdf_document->mutex);
@@ -86,6 +87,7 @@ zathura_error_t pdf_document_attachment_save(zathura_document_t* document, void*
     }
   }
   fz_catch(mupdf_document->ctx) {
+    g_mutex_unlock(&mupdf_document->mutex);
     return ZATHURA_ERROR_UNKNOWN;
   }
   g_mutex_unlock(&mupdf_document->mutex);

--- a/zathura-pdf-mupdf/document.c
+++ b/zathura-pdf-mupdf/document.c
@@ -55,7 +55,7 @@ zathura_error_t pdf_document_open(zathura_document_t* document) {
   }
   fz_catch(mupdf_document->ctx) {
     error = ZATHURA_ERROR_UNKNOWN;
-    return error;
+    goto error_free;
   }
 
   if (mupdf_document->document == NULL) {

--- a/zathura-pdf-mupdf/image.c
+++ b/zathura-pdf-mupdf/image.c
@@ -106,8 +106,11 @@ cairo_surface_t* pdf_page_image_get_cairo(zathura_page_t* page, void* data, zath
     goto error_free;
   }
 
-  surface = cairo_image_surface_create(CAIRO_FORMAT_RGB24, mupdf_image->w, mupdf_image->h);
-  if (surface == NULL) {
+  const int width  = fz_pixmap_width(mupdf_page->ctx, pixmap);
+  const int height = fz_pixmap_height(mupdf_page->ctx, pixmap);
+
+  surface = cairo_image_surface_create(CAIRO_FORMAT_RGB24, width, height);
+  if (surface == NULL || cairo_surface_status(surface) != CAIRO_STATUS_SUCCESS) {
     goto error_free;
   }
 
@@ -117,8 +120,6 @@ cairo_surface_t* pdf_page_image_get_cairo(zathura_page_t* page, void* data, zath
   unsigned char* s = fz_pixmap_samples(mupdf_page->ctx, pixmap);
   unsigned int n   = fz_pixmap_components(mupdf_page->ctx, pixmap);
 
-  const int height = fz_pixmap_height(mupdf_page->ctx, pixmap);
-  const int width  = fz_pixmap_width(mupdf_page->ctx, pixmap);
   for (int y = 0; y < height; y++) {
     for (int x = 0; x < width; x++) {
       guchar* p = surface_data + y * rowstride + x * 4;


### PR DESCRIPTION
This addresses two issues:

when reading or saving of attachment fails, the lock does not get released, leading to a freeze. Adding unlock to addresses this.

When an image is extracted, the buffer can be too small for the actual pixel data, causing a memory overwrite. Should be addressed by using the real image size.